### PR TITLE
rename dim of the kernel

### DIFF
--- a/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
@@ -36,7 +36,7 @@ namespace gol
 
         struct Evolution
         {
-            static constexpr uint32_t dim = DIM2;
+            static constexpr uint32_t kernelDim = DIM2;
 
             template<
                 typename T_Acc,
@@ -94,7 +94,7 @@ namespace gol
 
         struct RandomInit
         {
-            static constexpr uint32_t dim = DIM2;
+            static constexpr uint32_t kernelDim = DIM2;
 
             template<
                 typename T_Acc,

--- a/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
@@ -108,7 +108,7 @@
 #define __cudaKernel(...) {                                                    \
     using KernelType = __VA_ARGS__;                                            \
     const KernelType theOneAndOnlyKernel;                                      \
-    using KernelDim = ::PMacc::alpaka::Dim<KernelType::dim>;                   \
+    using KernelDim = ::PMacc::alpaka::Dim<KernelType::kernelDim>;             \
     CUDA_CHECK_KERNEL_MSG(::alpaka::wait::wait(::PMacc::Environment<>::get().DeviceManager().getAccDevice()),"Crash before kernel call"); \
     PMacc::TaskKernel *taskKernel = ::PMacc::Environment<>::get().Factory().createTaskKernel(#__VA_ARGS__);     \
     PMACC_CUDAKERNELCONFIG

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -35,7 +35,7 @@ namespace PMacc
 
 struct KernelSetValueOnDeviceMemory
 {
-    static constexpr uint32_t dim = DIM1;
+    static constexpr uint32_t kernelDim = DIM1;
 
     template<
         typename T_Acc

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
@@ -86,7 +86,7 @@ template<
 >
 struct KernelSetValue
 {
-    static constexpr uint32_t dim = T_dim;
+    static constexpr uint32_t kernelDim = T_dim;
 
     template<
         typename T_Acc,


### PR DESCRIPTION
rename `dim` inside the kernel to `kernelDim`

This avoids naming conflicts in many kernel. Thus we are in an early state of development this change can be done without problems.