### PR TITLE
update `__picKernelArea()`

### DIFF
--- a/src/picongpu/include/fields/FieldJ.tpp
+++ b/src/picongpu/include/fields/FieldJ.tpp
@@ -298,9 +298,9 @@ void FieldJ::computeCurrent( ParticlesClass &parClass, uint32_t )
 template<uint32_t AREA, class T_CurrentInterpolation>
 void FieldJ::addCurrentToEMF( T_CurrentInterpolation& myCurrentInterpolation )
 {
-    __picKernelArea( ( kernelAddCurrentToEMF ),
-                     cellDescription,
-                     AREA )
+    __picKernelArea( cellDescription,
+                     AREA,
+                     kernelAddCurrentToEMF )
         ( MappingDesc::SuperCellSize::toRT( ).toDim3( ) )
         ( this->fieldE->getDeviceDataBox( ),
           this->fieldB->getDeviceDataBox( ),

--- a/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
+++ b/src/picongpu/include/fields/MaxwellSolver/Yee/YeeSolver.hpp
@@ -67,14 +67,14 @@ private:
         /* Courant-Friedrichs-Levy-Condition for Yee Field Solver: */
         PMACC_CASSERT_MSG(Courant_Friedrichs_Levy_condition_failure____check_your_gridConfig_param_file,
             (SPEED_OF_LIGHT*SPEED_OF_LIGHT*DELTA_T*DELTA_T*INV_CELL2_SUM)<=1.0);
-        
+
         typedef SuperCellDescription<
                 SuperCellSize,
                 typename CurlB::LowerMargin,
                 typename CurlB::UpperMargin
                 > BlockArea;
 
-        __picKernelArea((kernelUpdateE<BlockArea, CurlB>), m_cellDescription, AREA)
+        __picKernelArea(m_cellDescription, AREA, kernelUpdateE<BlockArea, CurlB>)
                 (SuperCellSize::toRT().toDim3())
                 (this->fieldE->getDeviceDataBox(), this->fieldB->getDeviceDataBox());
     }
@@ -88,7 +88,7 @@ private:
                 typename CurlE::UpperMargin
                 > BlockArea;
 
-        __picKernelArea((kernelUpdateBHalf<BlockArea, CurlE>), m_cellDescription, AREA)
+        __picKernelArea(m_cellDescription, AREA, kernelUpdateBHalf<BlockArea, CurlE>)
                 (SuperCellSize::toRT().toDim3())
                 (this->fieldB->getDeviceDataBox(),
                 this->fieldE->getDeviceDataBox());

--- a/src/picongpu/include/fields/background/cellwiseOperation.hpp
+++ b/src/picongpu/include/fields/background/cellwiseOperation.hpp
@@ -111,7 +111,7 @@ namespace cellwiseOperation
                 totalCellOffset += m_cellDescription.getSuperCellSize() * m_cellDescription.getBorderSuperCells();
 
             /* start kernel */
-            __picKernelArea((kernelCellwiseOperation<T_OpFunctor>), m_cellDescription, T_Area)
+            __picKernelArea(m_cellDescription, T_Area, kernelCellwiseOperation<T_OpFunctor>)
                     (SuperCellSize::toRT().toDim3())
                     (field->getDeviceDataBox(), opFunctor, valFunctor, totalCellOffset, currentStep);
         }

--- a/src/picongpu/include/particles/Particles.tpp
+++ b/src/picongpu/include/particles/Particles.tpp
@@ -179,7 +179,7 @@ void Particles<T_ParticleDescription>::update(uint32_t )
 
     dim3 block( MappingDesc::SuperCellSize::toRT().toDim3() );
 
-    __picKernelArea( kernelMoveAndMarkParticles<BlockArea>, this->cellDescription, CORE + BORDER )
+    __picKernelArea(this->cellDescription, CORE + BORDER, kernelMoveAndMarkParticles<BlockArea>)
         (block)
         ( this->getDeviceParticlesBox( ),
           this->fieldE->getDeviceDataBox( ),
@@ -205,8 +205,10 @@ void Particles<T_ParticleDescription>::initGas( T_GasFunctor& gasFunctor,
     totalGpuCellOffset.y( ) += numSlides * localCells.y( );
 
     dim3 block( MappingDesc::SuperCellSize::toRT( ).toDim3( ) );
-    __picKernelArea( (kernelFillGridWithParticles<Particles<T_ParticleDescription> >),
-                      this->cellDescription, CORE + BORDER)
+    __picKernelArea( 
+        this->cellDescription, 
+        CORE + BORDER,
+        kernelFillGridWithParticles<Particles<T_ParticleDescription> >)
         (block)
         ( gasFunctor, positionFunctor, totalGpuCellOffset, this->particlesBuffer->getDeviceParticleBox( ) );
 
@@ -222,7 +224,7 @@ void Particles<T_ParticleDescription>::deviceCloneFrom( Particles< T_SrcParticle
     dim3 block( PMacc::math::CT::volume<SuperCellSize>::type::value );
 
     log<picLog::SIMULATION_STATE > ( "clone species %1%" ) % FrameType::getName( );
-    __picKernelArea( kernelCloneParticles, this->cellDescription, CORE + BORDER )
+    __picKernelArea( this->cellDescription, CORE + BORDER, kernelCloneParticles )
         (block) ( this->getDeviceParticlesBox( ), src.getDeviceParticlesBox( ), functor );
     this->fillAllGaps( );
 }
@@ -234,7 +236,7 @@ void Particles<T_ParticleDescription>::manipulateAllParticles( uint32_t currentS
 
     dim3 block( MappingDesc::SuperCellSize::toRT( ).toDim3( ) );
 
-    __picKernelArea( kernelManipulateAllParticles, this->cellDescription, CORE + BORDER )
+    __picKernelArea( this->cellDescription, CORE + BORDER, kernelManipulateAllParticles )
         (block)
         ( this->particlesBuffer->getDeviceParticleBox( ),
           functor );

--- a/src/picongpu/include/particles/ParticlesFunctors.hpp
+++ b/src/picongpu/include/particles/ParticlesFunctors.hpp
@@ -301,7 +301,7 @@ struct CallIonization
              * "blocks" will be calculated from "this->cellDescription" and "CORE + BORDER"
              * "threads" is calculated from the previously defined vector "block"
              */
-            __picKernelArea( particles::ionization::kernelIonizeParticles, *cellDesc, CORE + BORDER )
+            __picKernelArea( *cellDesc, CORE + BORDER, particles::ionization::kernelIonizeParticles )
                 (block)
                 ( srcSpeciesPtr->getDeviceParticlesBox( ),
                   electronsPtr->getDeviceParticlesBox( ),

--- a/src/picongpu/include/plugins/EnergyParticles.hpp
+++ b/src/picongpu/include/plugins/EnergyParticles.hpp
@@ -314,7 +314,7 @@ private:
         dim3 block(MappingDesc::SuperCellSize::toRT().toDim3()); /* GPU parallelization */
 
         /* kernel call = sum all particle energies on GPU */
-        __picKernelArea(kernelEnergyParticles, *cellDescription, AREA)
+        __picKernelArea(*cellDescription, AREA, kernelEnergyParticles)
             (block)
             (particles->getDeviceParticlesBox(),
              gEnergy->getDeviceBuffer().getDataBox());

--- a/src/picongpu/include/plugins/PositionsParticles.hpp
+++ b/src/picongpu/include/plugins/PositionsParticles.hpp
@@ -256,7 +256,7 @@ private:
         gParticle->getDeviceBuffer().setValue(positionParticleTmp);
         dim3 block(SuperCellSize::toRT().toDim3());
 
-        __picKernelArea(kernelPositionsParticles, *cellDescription, AREA)
+        __picKernelArea(*cellDescription, AREA, kernelPositionsParticles)
             (block)
             (particles->getDeviceParticlesBox(),
              gParticle->getDeviceBuffer().getBasePointer());

--- a/src/picongpu/include/plugins/SumCurrents.hpp
+++ b/src/picongpu/include/plugins/SumCurrents.hpp
@@ -184,7 +184,7 @@ private:
         sumcurrents->getDeviceBuffer().setValue(float3_X::create(0.0));
         dim3 block(MappingDesc::SuperCellSize::toRT().toDim3());
 
-        __picKernelArea(kernelSumCurrents, *cellDescription, CORE + BORDER)
+        __picKernelArea(*cellDescription, CORE + BORDER, kernelSumCurrents)
             (block)
             (fieldJ->getDeviceDataBox(),
              sumcurrents->getDeviceBuffer().getBasePointer());

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -523,7 +523,7 @@ public:
         typedef MappingDesc::SuperCellSize SuperCellSize;
         assert(cellDescription != NULL);
         //create image fields
-        __picKernelArea((kernelPaintFields), *cellDescription, CORE + BORDER)
+        __picKernelArea(*cellDescription, CORE + BORDER, kernelPaintFields)
             (SuperCellSize::toRT().toDim3())
             (fieldE->getDeviceDataBox(),
              fieldB->getDeviceDataBox(),
@@ -574,7 +574,7 @@ public:
         DataSpace<DIM2> blockSize2D(blockSize[m_transpose.x()], blockSize[m_transpose.y()]);
 
         //create image particles
-        __picKernelArea((kernelPaintParticles3D), *cellDescription, CORE + BORDER)
+        __picKernelArea(*cellDescription, CORE + BORDER, kernelPaintParticles3D)
             (SuperCellSize::toRT().toDim3(), blockSize2D.productOfComponents() * sizeof (float_X))
             (particles->getDeviceParticlesBox(),
              img->getDeviceBuffer().getDataBox(),


### PR DESCRIPTION
- change interface of `__picKernelArea()` to support alpaka
- use new interface for kernel calls inside of PIConGPU