### PR TITLE
add atomic hierarchy to `atomicAll*`

### DIFF
--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -332,11 +332,8 @@ DINLINE void operator()( const T_Acc& acc, ParBox pb, Mapping mapper ) const
                 isParticleArray[idx] = lastFrame[threadIndex][multiMask_];
                 if ( isParticleArray[idx] == true ) //\todo: bits zählen
                 {
-#if (PMACC_CUDA_ENABLED == 1)
-                    nvidia::atomicAllInc( acc, &counterParticles );
-#else
+                    nvidia::atomicAllInc( acc, &counterParticles, ::alpaka::hierarchy::Threads() );
                     ++counterParticles;
-#endif
                 }
             },
             T_elemSize
@@ -349,11 +346,7 @@ DINLINE void operator()( const T_Acc& acc, ParBox pb, Mapping mapper ) const
                 const int threadIndex = stridedLinearThreadIdx + idx;
                 if ( threadIndex < counterParticles && isParticleArray[idx] == false )
                 {
-#if (PMACC_CUDA_ENABLED == 1)
-                    const int localGapIdx = nvidia::atomicAllInc( acc, &counterGaps );
-#else
-                    const int localGapIdx = counterGaps++;
-#endif
+                    const int localGapIdx = nvidia::atomicAllInc( acc, &counterGaps, ::alpaka::hierarchy::Threads() );
                     gapIndices_sh[localGapIdx] = threadIndex;
                 }
             },
@@ -450,11 +443,7 @@ DINLINE void operator()( const T_Acc& acc, ParBox pb, Mapping mapper ) const
                 // find gaps
                 if ( firstFrame[threadIndex][multiMask_] == 0 )
                 {
-#if (PMACC_CUDA_ENABLED == 1)
-                    localGapIdxArray[idx] = nvidia::atomicAllInc( acc, &counterGaps );
-#else
-                    localGapIdxArray[idx] = counterGaps++;
-#endif
+                    localGapIdxArray[idx] = nvidia::atomicAllInc( acc, &counterGaps, ::alpaka::hierarchy::Threads() );
                 }
             },
             T_elemSize
@@ -478,11 +467,7 @@ DINLINE void operator()( const T_Acc& acc, ParBox pb, Mapping mapper ) const
                 // search particles for gaps
                 if ( lastFrame[threadIndex][multiMask_] == 1 )
                 {
-#if (PMACC_CUDA_ENABLED == 1)
-                    int localParticleIdx = nvidia::atomicAllInc( acc, &counterParticles );
-#else
-                    int localParticleIdx = counterParticles++;
-#endif
+                    int localParticleIdx = nvidia::atomicAllInc( acc, &counterParticles, ::alpaka::hierarchy::Threads() );
                     particleIndices_sh[localParticleIdx] = threadIndex;
                 }
             },
@@ -646,11 +631,7 @@ DINLINE void operator()( const T_Acc& acc, ParBox pb,
                 const int linearThreadIdx = stridedLinearThreadIdx + idx;
                 if ( frame[linearThreadIdx][multiMask_] == 1 )
                 {
-#if (PMACC_CUDA_ENABLED == 1)
-                    bashIdxArray[idx] = nvidia::atomicAllInc( acc, &numBashedParticles );
-#else
-                    bashIdxArray[idx] = numBashedParticles++;
-#endif
+                    bashIdxArray[idx] = nvidia::atomicAllInc( acc, &numBashedParticles, ::alpaka::hierarchy::Threads() );
                 }
             },
             T_elemSize

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -446,12 +446,8 @@ struct PushParticlePerFrame
          */
         if (direction >= 2)
         {
-#if (PMACC_CUDA_ENABLED == 1)
             /* if we did not use atomic we would get a WAW error */
-            nvidia::atomicAllExch(acc, &mustShift, 1);
-#else
-            mustShift = 1;
-#endif
+            nvidia::atomicAllExch(acc, &mustShift, 1,::alpaka::hierarchy::Threads());
         }
     }
 };

--- a/src/picongpu/include/particles/ParticlesInit.kernel
+++ b/src/picongpu/include/particles/ParticlesInit.kernel
@@ -131,7 +131,7 @@ DINLINE void operator()(const T_Acc& acc,
             totalNumParsPerCellArray(idx) = numParsPerCellArray(idx);
 
             if (numParsPerCellArray(idx) > 0)
-                nvidia::atomicAllExch(acc, &finished, 0); //one or more cells have particles to create
+                nvidia::atomicAllExch(acc, &finished, 0, ::alpaka::hierarchy::Threads()); //one or more cells have particles to create
 
         },
         T_ElemSize::toRT(),

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -124,7 +124,7 @@ struct CreateParticlesFromParticleImpl : private T_Functor
             __syncthreads();
             if (isParticle && numParToCreate > 0)
             {
-                freeSlot = nvidia::atomicAllInc(acc, &particlesInDestSuperCell);
+                freeSlot = nvidia::atomicAllInc(acc, &particlesInDestSuperCell, ::alpaka::hierarchy::Threads());
             }
             --numParToCreate;
             if (freeSlot>-1 && freeSlot < cellsInSuperCell)

--- a/src/picongpu/include/plugins/output/WriteSpeciesCommon.hpp
+++ b/src/picongpu/include/plugins/output/WriteSpeciesCommon.hpp
@@ -58,7 +58,11 @@ struct MallocMemory
         type* ptr = NULL;
         if (size != 0)
         {
+#if ( PMACC_CUDA_ENABLED == 1 )
             CUDA_CHECK(cudaHostAlloc(&ptr, size * sizeof (type), cudaHostAllocMapped));
+#else
+            ptr = new type[size];
+#endif
         }
         v1.getIdentifier(T_Type()) = VectorDataBox<type>(ptr);
 
@@ -119,7 +123,11 @@ struct GetDevicePtr
         type* srcPtr = src.getIdentifier(T_Type()).getPointer();
         if (srcPtr != NULL)
         {
+#if ( PMACC_CUDA_ENABLED == 1 )
             CUDA_CHECK(cudaHostGetDevicePointer(&ptr, srcPtr, 0));
+#else
+            ptr = srcPtr;
+#endif
         }
         dest.getIdentifier(T_Type()) = VectorDataBox<type>(ptr);
     }
@@ -136,7 +144,11 @@ struct FreeMemory
         type* ptr = value.getIdentifier(T_Type()).getPointer();
         if (ptr != NULL)
         {
+#if ( PMACC_CUDA_ENABLED == 1 )
             CUDA_CHECK(cudaFreeHost(ptr));
+#else
+            delete[] ptr;
+#endif
             ptr=NULL;
         }
     }

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -334,7 +334,7 @@ operator()(const T_Acc& acc,
             if (globalCell == slice)
 #endif
             {
-                nvidia::atomicAllExch(acc, (int*) &isValid,1); /*WAW Error in cuda-memcheck racecheck*/
+                nvidia::atomicAllExch(acc, (int*) &isValid, 1, ::alpaka::hierarchy::Threads()); /*WAW Error in cuda-memcheck racecheck*/
                 isImageThread = true;
             }
 

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -252,7 +252,7 @@ void operator()(const T_Acc& acc,
 #if(RAD_MARK_PARTICLE>1) || (RAD_ACTIVATE_GAMMA_FILTER!=0)
                     if (par[radiationFlag_])
 #endif
-                    saveParticleAt = nvidia::atomicAllInc(acc, &counter_s);
+                    saveParticleAt = nvidia::atomicAllInc(acc, &counter_s, ::alpaka::hierarchy::Threads());
                     /* for information:
                     *   atomicAdd returns an int with the previous
                     *   value of "counter_s" != -1


### PR DESCRIPTION
- extent atomicAll with alpaka hierarchy parameter
- define hierarchy for all `atomicAll*` operations