### PR TITLE
fix broken runtime cudaSetDevice

### DIFF
--- a/src/libPMacc/include/Environment.hpp
+++ b/src/libPMacc/include/Environment.hpp
@@ -204,6 +204,7 @@ private:
             cudaSetDevice(tryDeviceId);
             break;
 #endif
+#if 0
 #if ( PMACC_CUDA_ENABLED == 1 )
             if(rc == cudaSuccess)
             {
@@ -247,6 +248,7 @@ private:
             {
                 CUDA_CHECK(rc); /*error message*/
             }
+#endif
 #endif
         }
     }


### PR DESCRIPTION
alpaka throws always an error if something went wrong while the device selection.
This is currently not handled in cupla, therefore we disable some code in PMacc.