### PR TITLE
Update picongpu.profile.example

### DIFF
--- a/src/picongpu/submit/taurus-tud/picongpu.profile.example
+++ b/src/picongpu/submit/taurus-tud/picongpu.profile.example
@@ -10,7 +10,7 @@ module load gnuplot/4.6.1
 
 # Compilers ###################################################################
 ### GCC
-module load gcc/5.1.0 boost/1.58.0-gnu5.1
+module load gcc/5.3.0 boost/1.60.0-gnu5.3
 ### ICC
 #module load intel/2015.3.187 boost/1.59.0-intel2015.3.187
 ### PGI


### PR DESCRIPTION
Updated gcc/boost version since cupla requires boost >= 1.59